### PR TITLE
Use explicit integer sizes

### DIFF
--- a/kaitaistruct.lua
+++ b/kaitaistruct.lua
@@ -79,15 +79,15 @@ end
 --.............................................................................
 
 function KaitaiStream:read_s2be()
-    return string.unpack('>h', self._io:read(2))
+    return string.unpack('>i2', self._io:read(2))
 end
 
 function KaitaiStream:read_s4be()
-    return string.unpack('>i', self._io:read(4))
+    return string.unpack('>i4', self._io:read(4))
 end
 
 function KaitaiStream:read_s8be()
-    return string.unpack('>l', self._io:read(8))
+    return string.unpack('>i8', self._io:read(8))
 end
 
 --.............................................................................
@@ -95,15 +95,15 @@ end
 --.............................................................................
 
 function KaitaiStream:read_s2le()
-    return string.unpack('<h', self._io:read(2))
+    return string.unpack('<i2', self._io:read(2))
 end
 
 function KaitaiStream:read_s4le()
-    return string.unpack('<i', self._io:read(4))
+    return string.unpack('<i4', self._io:read(4))
 end
 
 function KaitaiStream:read_s8le()
-    return string.unpack('<l', self._io:read(8))
+    return string.unpack('<i8', self._io:read(8))
 end
 
 -------------------------------------------------------------------------------
@@ -119,15 +119,15 @@ end
 --.............................................................................
 
 function KaitaiStream:read_u2be()
-    return string.unpack('>H', self._io:read(2))
+    return string.unpack('>I2', self._io:read(2))
 end
 
 function KaitaiStream:read_u4be()
-    return string.unpack('>I', self._io:read(4))
+    return string.unpack('>I4', self._io:read(4))
 end
 
 function KaitaiStream:read_u8be()
-    return string.unpack('>L', self._io:read(8))
+    return string.unpack('>I8', self._io:read(8))
 end
 
 --.............................................................................
@@ -135,15 +135,15 @@ end
 --.............................................................................
 
 function KaitaiStream:read_u2le()
-    return string.unpack('<H', self._io:read(2))
+    return string.unpack('<I2', self._io:read(2))
 end
 
 function KaitaiStream:read_u4le()
-    return string.unpack('<I', self._io:read(4))
+    return string.unpack('<I4', self._io:read(4))
 end
 
 function KaitaiStream:read_u8le()
-    return string.unpack('<L', self._io:read(8))
+    return string.unpack('<I8', self._io:read(8))
 end
 
 --=============================================================================


### PR DESCRIPTION
Instead of native `short`, `int` and `long` sizes.

See https://www.lua.org/manual/5.3/manual.html#6.4.2
and https://www.lua.org/source/5.3/lstrlib.c.html#getoption

Ref #2